### PR TITLE
Delete saves past retention 

### DIFF
--- a/main.go
+++ b/main.go
@@ -25,7 +25,7 @@ func initDB(path string) *sql.DB {
 		s3_bucket VARCHAR(255) NOT NULL,
 		prefix TEXT NOT NULL,
 		working_path TEXT NOT NULL,
-    	active BOOLEAN DEFAULT TRUE NOT NULL,
+		active BOOLEAN DEFAULT TRUE NOT NULL,
 		created_at BIGINT DEFAULT CURRENT_TIMESTAMP
 	);
 	


### PR DESCRIPTION
Delete saves older than the designated number of saves to retain. The default is 5. This also updates the save record to be deleted after the file is deleted in S3.